### PR TITLE
Fix AttributeError for TriangleMesh object

### DIFF
--- a/body_measurement.py
+++ b/body_measurement.py
@@ -194,7 +194,7 @@ class BodyMeasurementSystem:
         # Calculate scale factor if calibration height is provided
         if self.calibration_height:
             # The model points are in meters. Find the height of the model.
-            points = np.asarray(self.model.points)
+            points = np.asarray(self.model.vertices)
             min_y = np.min(points[:, 1])
             max_y = np.max(points[:, 1])
             


### PR DESCRIPTION
The `open3d.geometry.TriangleMesh` object does not have a `points` attribute to access its vertices. The correct attribute is `vertices`.

This commit fixes the `AttributeError` in the `_reconstruct_3d_model` method by changing `self.model.points` to `self.model.vertices`.